### PR TITLE
Added three potential methods for URLs:

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,20 +1,14 @@
 import './App.scss';
 import { BrowserRouter, Switch, Route } from 'react-router-dom';
-import { 
-  homeURL,
-  aboutURL,
-  contactUsURL,
-  dashboardURL,
-  loginRegisterURL,
-  patronPortalURL   
-} from './utilities/routerConfig';
+import {routes} from './utilities/routerConfig';
 import Header from './components/Header/Header';
 import HomePage from './pages/Home/Home';
 import AboutPage from './pages/About/About';
-import ContactPage from './pages/Contact/Contact';
 import DashboardPage from './pages/Dashboard/Dashboard';
 import LoginRegisterPage from './pages/LoginRegister/LoginRegister';
-import PatronPortalPage from './pages/PatronPortal/PatronPortal';
+// import ContactPage from './pages/Contact/Contact';
+// import PatronPortalPage from './pages/PatronPortal/PatronPortal';
+const {landingURLs,dashboardURLs} = routes;
 
 function App() {
 
@@ -23,12 +17,12 @@ function App() {
       <BrowserRouter>
         <Header />
         <Switch>
-          <Route exact path={homeURL} component={HomePage} />
-          <Route path={aboutURL} component={AboutPage} />
-          <Route path={contactUsURL} component={ContactPage} />
-          <Route path={dashboardURL} component={DashboardPage} />
-          <Route path={loginRegisterURL} component={LoginRegisterPage}/>          
-          <Route path={patronPortalURL} component={PatronPortalPage} />
+          <Route exact path={landingURLs.main} component={HomePage} />
+          <Route path={landingURLs.about} component={AboutPage} />
+          <Route path={dashboardURLs.main} component={DashboardPage} />
+          <Route path={landingURLs.loginRegister} component={LoginRegisterPage}/>          
+          {/* <Route path={contactUsURL} component={ContactPage} /> */}
+          {/* <Route path={patronPortalURL} component={PatronPortalPage} /> */}
         </Switch>
 
       </BrowserRouter>

--- a/src/components/DashboardNav/DashboardNav.tsx
+++ b/src/components/DashboardNav/DashboardNav.tsx
@@ -1,38 +1,40 @@
 import React from 'react';
 import { Switch, Route, NavLink } from 'react-router-dom';
-import { customerFaqURL, editProfileURL, foundItemURL, profileURL, reportsURL, searchItemsURL } from '../../utilities/routerConfig';
+import { routes } from '../../utilities/routerConfig';
+const { dashboardURLs } = routes;
 
 function DashboardNav() {
     return (
         <nav>
             <ul>
                 <li>
-                    <NavLink to={reportsURL}>Reports</NavLink>
+                    <NavLink to={dashboardURLs.addItem.main}>Add Item</NavLink>
                 </li>
                 <li>
-                    <NavLink to={foundItemURL}>Found Item</NavLink>
+                    <NavLink to={dashboardURLs.searchItems.main}>Search Items</NavLink>
                 </li>
                 <li>
-                    <NavLink to={searchItemsURL}>Search Items</NavLink>
+                    <NavLink to={dashboardURLs.compare}>Compare</NavLink>
                 </li>
                 <li>
-                    <NavLink to={profileURL}>Profile</NavLink>
+                    <NavLink to={dashboardURLs.itemMatches}>Item Matches</NavLink>
                 </li>
                 <li>
-                    <NavLink to={editProfileURL}>Edit Profile</NavLink>
+                    <NavLink to={dashboardURLs.reports}>Reports</NavLink>
                 </li>
                 <li>
-                    <NavLink to={customerFaqURL}>FAQs</NavLink>
+                    <NavLink to={dashboardURLs.settings}>Settings</NavLink>
+                </li>
+                <li>
+                    <NavLink to={dashboardURLs.messages}>Messsages</NavLink>
+                </li>
+                <li>
+                    <NavLink to={dashboardURLs.profile.main}>Profile</NavLink>
                 </li>
             </ul>
 
             <Switch>
-                <Route path={reportsURL} component={undefined} />
-                <Route path={foundItemURL} component={undefined} />
-                <Route path={searchItemsURL} component={undefined} />
-                <Route path={profileURL} component={undefined} />
-                <Route path={editProfileURL} component={undefined} />
-                <Route path={customerFaqURL} component={undefined} />
+                <Route path={dashboardURLs.addItem.main} component={undefined} />
             </Switch>
 
         </nav>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -4,7 +4,8 @@ import { Link } from 'react-router-dom';
 import AegisLogo from '../../assets/logo/aegis-logo.svg';
 import HeaderNav from '../HeaderNav/HeaderNav';
 import HamburgerIcon from '../../assets/icons/hamburger-menu.svg';
-import { homeURL } from '../../utilities/routerConfig';
+import { routes } from '../../utilities/routerConfig';
+const {landingURLs} = routes;
 
 function Header() {
     
@@ -47,7 +48,7 @@ function Header() {
             <div className="header__spacer"></div>
             <header className="header">
                 <div className="header__column">
-                    <Link to={homeURL}>
+                    <Link to={landingURLs.main}>
                         <img className="header__logo" src={AegisLogo} alt="logo" />
                     </Link>
                     <HeaderNav />

--- a/src/components/HeaderNav/HeaderNav.tsx
+++ b/src/components/HeaderNav/HeaderNav.tsx
@@ -1,21 +1,22 @@
 import './HeaderNav.scss';
 import { NavLink } from 'react-router-dom';
-import { aboutURL, loginRegisterURL, faqURL } from '../../utilities/routerConfig';
+import {routes} from '../../utilities/routerConfig';
+const {landingURLs} = routes;
 
 function HeaderNav() {
     return (
         <nav className="header-nav">
             <ul className="header-nav__items">
                 <li className="header-nav__item">
-                    <NavLink className="header-nav__link" activeClassName={undefined} to={aboutURL}>About
+                    <NavLink className="header-nav__link" activeClassName={undefined} to={landingURLs.about}>About
                     </NavLink>
                 </li>
                 <li className="header-nav__item">
-                    <NavLink className="header-nav__link" activeClassName={undefined} to={faqURL}>FAQ's
+                    <NavLink className="header-nav__link" activeClassName={undefined} to={landingURLs.faqs.client}>FAQ's
                     </NavLink>
                 </li>
                 <li className="header-nav__item">
-                    <NavLink className="header-nav__link" activeClassName={undefined} to={loginRegisterURL}>Register
+                    <NavLink className="header-nav__link" activeClassName={undefined} to={landingURLs.loginRegister}>Register
                     </NavLink>
                 </li>
             </ul>

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom';
-import { aboutURL, customerFaqURL } from '../../utilities/routerConfig';
+import { routes } from '../../utilities/routerConfig';
 import './Home.scss';
 import '../../styles/globals.scss';
 import ReturnToTop from '../../components/ReturnToTop/ReturnToTop';
@@ -7,6 +7,7 @@ import HomeContactUs from '../../components/HomeContactUs/HomeContactUs';
 import HomeReportingItem from '../../components/HomeReportingItem/HomeReportingItem';
 import HomeItemUpdate from '../../components/HomeItemUpdate/HomeItemUpdate';
 import DrawableSVG from '../../components/DrawableSVG/DrawableSVG';
+const { landingURLs } = routes;
 
 function Home() {
   return (
@@ -35,7 +36,7 @@ function Home() {
               A secure platform for reporting, logging and tracking lost and found items. By enhancing
               the communication process the interface eases the process for clients and hotel guests alike. 
             </p>
-            <Link to={aboutURL} className="about-intro__more">
+            <Link to={landingURLs.about} className="about-intro__more">
               Learn More
               <svg className="svg-icon__chevron" viewBox="0 0 12 22" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <rect width="14.7736" height="3.21165" transform="matrix(0.664353 0.747419 -0.664353 0.747419 2.18512 0)" fill="#FE5C32"/>
@@ -74,10 +75,10 @@ function Home() {
               best assist you, are you a client or a hotel guest? 
             </p>
             <div className="faq-intro__link-wrapper">
-              <Link to={customerFaqURL} className="faq-intro__link button--primary">
+              <Link to={landingURLs.faqs.client} className="faq-intro__link button--primary">
                 Client
               </Link>
-              <Link to={customerFaqURL} className="faq-intro__link button--secondary">
+              <Link to={landingURLs.faqs.guest} className="faq-intro__link button--secondary">
                 Guest
               </Link>
             </div>

--- a/src/utilities/routerConfig.js
+++ b/src/utilities/routerConfig.js
@@ -1,14 +1,136 @@
-export const homeURL = '/';
-export const aboutURL = '/about';
-export const contactUsURL = '/contact-us';
-export const dashboardURL = '/dashboard';
-export const loginRegisterURL = '/login-register';
-export const patronPortalURL = '/patron-portal';
-export const faqURL = '/faqs';
+/**
+ * Returns a url string based on key provided
+ * 
+ * @privateRemarks
+ * The most simple of the three options presented.
+ * Pros: Most performant as it requires no function call and/or recalculation.
+ * Clearly shows defined website structure divided into sections making urls
+ * easy to view and update.
+ * Cons: Not hugely customizable and any parameters will need to be declared
+ * inline. No default return for base path making reference a little wordier, i.e.
+ * instead of dashboardURLs.profile you would need to use dashboardURLs.profile.main
+ * 
+ */
+export const routes = {
+  landingURLs: {
+    main: '/',
+    about: '/about',
+    faqs:{
+      client:'faqs?branch=client',
+      guest: 'faqs?branch=guest'
+    },
+    loginRegister: '/login-register'
+  },
+  dashboardURLs: {
+    main: '/dashboard',
+    addItem: {
+      main:'/dashboard/add-item',
+      lost:'/dashboard/add-item/lost',
+      found:'/dashboard/add-item/found',
+    },
+    searchItems: {
+      main:'/dashboard/search-items',
+      lost:'/dashboard/search-items/lost',
+      found:'/dashboard/search-items/found',
+    },
+    compare: 'dashboard/compare',
+    itemMatches: 'dashboard/item-matches',
+    reports:'/dashboard/reports',
+    settings: '/dashboard/settings',
+    messages: '/dashboard/messages',
+    profile: {
+      main:`/dashboard/profile`,
+      edit:'/dashboard/profile/edit'
+    },
+  }
+}
 
-export const reportsURL = `${dashboardURL}/reports`;
-export const foundItemURL = `${dashboardURL}/found-item`;
-export const profileURL = `${dashboardURL}/profile`;
-export const editProfileURL = `${profileURL}/edit`;
-export const customerFaqURL = `${dashboardURL}/faqs`;
-export const searchItemsURL = `${dashboardURL}/search-items`;
+/**
+ * Returns a url string based on parameters passed
+ * 
+ * @privateRemark
+ * Pros: Simple one-liner to handle multiple paths, easy to update if we want to inject parameters
+ * Cons: Harder to see at a glance what our paths are for every endpoint and does not exhibit any autocomplete/intellisence
+ * . We would need to rely more on the React Router defined paths or leave reference here. An alternative
+ * fix would be to add some validation, i.e. before return of string:
+ * const pageOptions = ['main','addItem','searchItems','compare','itemMatches','reports','settings','messages','profile'];
+ *  if (!pageOptions.includes(page)) throw Error
+ * You could improve the performance of the above by changing it to a Set or Obj
+ * 
+ * @example exampleOne
+ * dashboardLiterals() returns:
+ * '/dashboard
+ * @example exampleTwo
+ * dashboardLiterals('profile') returns:
+ * '/dashboard/profile'
+ * @example exampleThree
+ * dashboardLiterals('profile','edit') returns:
+ * 'dashboard/profile/edit'
+ * @example exampleFour
+ * Let's say we decided we now need to pass in a query param to one of the paths, this is now easy to do:
+ * dashboardLiterals('profile?id=346','edit') returns:
+ * 'dashboard/profile?id=346/edit'
+ * 
+ * @param {string} page -If left empty, will omit the corresponding '/' of the url
+ * @param {string} subpage -If left empty, will omit the corresponding '/' of the url 
+ * @returns {string} representing the corresponding url path for React Router
+ */
+const dashboardLiterals = ((page,subpage) => (`/dashboard${page?`/${page}`:''}${subpage?`/${subpage}`:''}`));
+
+/**
+ * Returns a url string based on parameters passed
+ * 
+ * @privateRemark
+ * Similar invocation process to the above except the paths are limited to declared keys to limit errors.
+ * Also has default for each page with multiple paths which can be updated, not always necessary however
+ * 
+ * Pros: Easy to review and update each path in one location. Keys clearly show each structure of urls and which
+ * path belong under which section.
+ * Cons: Harder to inject parameters into specific paths. Could however covert the necessary key into a
+ * function so that param's could be passed instead, i.e. with profile:
+ *    profile:(param = '') =>({
+        main:`/dashboard/profile${param}`,
+        edit:'/dashboard/profile${param}/edit'
+      }[subpage]),
+    Would be invoked with:
+      dashboardKeysWithDefault('profile')('?id=346')
+ * Or could more easily pass a third param to func (dashboardKeysWithDefault('profile','main','?id=346')), this
+ * would be a little more consistent as it wouldn't require a second invocation but can get a little more tedius
+ *
+ * @example exampleOne
+ * dashBoardKeysWithDefault() returns:
+ * '/dashboard
+ * @example exampleTwo
+ * dashBoardKeysWithDefault('profile') returns:
+ * '/dashboard/profile'
+ * @example exampleThree
+ * dashBoardKeysWithDefault('profile','edit') returns:
+ * 'dashboard/profile/edit'
+ * 
+ * @param {string} page -If left empty, will omit the corresponding '/' of the url
+ * @param {string} subpage -If left empty, will omit the corresponding '/' of the url 
+ * @returns {string} representing the corresponding url path for React Router
+ */
+
+ const dashboardKeysWithDefault = ((page='main',subpage="main") => (
+  {
+    main:'/dashboard',
+    addItem: {
+      main:'/dashboard/add-item',
+      lost:'/dashboard/add-item/lost',
+      found:'/dashboard/add-item/found',
+    }[subpage],
+    searchItems: {
+      main:'/dashboard/search-items',
+      lost:'/dashboard/search-items/lost',
+      found:'/dashboard/search-items/found',
+    }[subpage],
+    compare: 'dashboard/compare',
+    itemMatches: 'dashboard/item-matches',
+    reports:'/dashboard/reports',
+    profile: {
+      main:`/dashboard/profile`,
+      edit:'/dashboard/profile/edit'
+    }[subpage],
+  }[page]
+))


### PR DESCRIPTION
1. Simple object with nested keys for each route
2. A function that returns an object literal with the routes passed
3. A function that returns nested keys but has default paths
Currently all in-use paths updated to use option 1. 
Have commented out some paths which are not used in current Figma design. These can be removed once confirmed in PR review (re: ContactPage and PatronPortalPage). Which option we end up using may be determined by where we use queryParams in our url's.